### PR TITLE
fix: add site_url so CSS loads correctly on GitHub Pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: IU Alumni Docs
 site_description: Technical documentation for the IU Alumni platform
+site_url: https://iu-alumni.github.io/docs/
 docs_dir: src
 theme:
   name: material


### PR DESCRIPTION
## Problem

CSS and all static assets were broken on the live docs site (`https://iu-alumni.github.io/docs/`).

Without `site_url`, MkDocs generates absolute asset paths relative to `/`:

```html
<link href="/assets/stylesheets/main.css">
```

This resolves to `iu-alumni.github.io/assets/...` — a 404 — instead of `iu-alumni.github.io/docs/assets/...`.

## Fix

Add one line to `mkdocs.yml`:

```yaml
site_url: https://iu-alumni.github.io/docs/
```

MkDocs now generates correct paths prefixed with `/docs/`.