### PR TITLE
fix: add index.md home page to resolve 404 on root URL

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ markdown_extensions:
       permalink: true
 
 nav:
+  - Home: index.md
   - Technical Documentation:
     - System Overview: technical/overview.md
     - Backend: technical/backend.md

--- a/src/index.md
+++ b/src/index.md
@@ -1,0 +1,45 @@
+# IU Alumni Platform — Documentation
+
+Welcome to the technical and project documentation for the **IU Alumni** platform.
+
+## What's here
+
+| Section | Description |
+| ------- | ----------- |
+| [Technical Documentation](technical/overview.md) | Architecture, stack decisions, and component design with Mermaid diagrams |
+| [Requirements](requirements/functional.md) | Functional requirements, quality attributes, and use-case specifications |
+| [Metrics & Analytics](analytics/metrics.md) | KPIs, engagement metrics, and measurement methodology |
+| [Sprints](sprints/sprint-0/team-meeting-1.md) | Meeting notes, retrospectives, and sprint records |
+
+## Quick architecture overview
+
+```mermaid
+graph TD
+    subgraph Clients
+        M[Mobile App<br/>Flutter]
+        W[Admin Portal<br/>Nuxt 3]
+    end
+    subgraph Backend
+        API[FastAPI<br/>REST + Auth]
+        DB[(PostgreSQL)]
+    end
+    subgraph Infrastructure
+        SW[Docker Swarm]
+        LB[Nginx Proxy]
+    end
+
+    M --> LB
+    W --> LB
+    LB --> API
+    API --> DB
+    API --> SW
+```
+
+## Repository links
+
+| Repo | Purpose |
+| ---- | ------- |
+| [iu-alumni-backend](https://github.com/iu-alumni/iu-alumni-backend) | FastAPI backend service |
+| [iu-alumni-frontend](https://github.com/iu-alumni/iu-alumni-frontend) | Nuxt 3 admin portal |
+| [iu-alumni-mobile](https://github.com/iu-alumni/iu-alumni-mobile) | Flutter mobile app |
+| [iu-alumni-infra](https://github.com/iu-alumni/iu-alumni-infra) | Ansible + Terraform infrastructure |


### PR DESCRIPTION
## Problem

Visiting `https://iu-alumni.github.io/docs/` returned a 404 because there was no `src/index.md` file for MkDocs to serve as the home page.

## Fix

- Add `src/index.md` with a welcome page, quick architecture Mermaid diagram, and links to all sections
- Add `Home: index.md` as the first entry in the `nav` in `mkdocs.yml`