### PR TITLE
ci: add build check on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Build (PR)
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build docs
+        run: npm run docs:build


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` that runs `npm run docs:build` on every PR targeting `main`.

VitePress build catches:
- Dead links (like the one that broke the site after the file rename)
- Broken Mermaid/markdown syntax
- Config errors in `config.ts`

This runs separately from `deploy.yml` — no artifact upload or Pages deployment, just a build gate.