### PR TITLE
chore: expand site description in VitePress config

### DIFF
--- a/src/.vitepress/config.ts
+++ b/src/.vitepress/config.ts
@@ -4,7 +4,7 @@ import { withMermaid } from "vitepress-plugin-mermaid";
 export default withMermaid(
   defineConfig({
     title: "IU Alumni Docs",
-    description: "Technical documentation for the IU Alumni platform",
+    description: "Technical and project documentation for the IU Alumni platform",
     base: "/docs/",
 
     themeConfig: {


### PR DESCRIPTION
Minor wording improvement: `Technical documentation` → `Technical and project documentation` to better reflect that the site also covers sprint notes, requirements, and metrics.