### PR TITLE
docs: update backend docs — map endpoint, cursor pagination, HTML email templates

### DIFF
--- a/src/technical/backend.md
+++ b/src/technical/backend.md
@@ -168,7 +168,7 @@ All list endpoints (`GET /profile/users`, `GET /events/`) use **cursor-based pag
 
 The cursor is a **base64-encoded JSON object** containing the sort key(s) of the last item seen.
 
-```
+```text
 base64( JSON({ "id": "uuid" }) )               # ID-only cursor
 base64( JSON({ "id": "uuid", "dt": "iso8601" }) )  # date+ID cursor (events)
 ```
@@ -204,6 +204,7 @@ List endpoints return lightweight schemas to avoid sending large binary fields (
 4. Results are grouped and counted — the mobile client receives a single flat list of pins with no extra round-trips.
 
 **Filters applied:**
+
 - `show_location = true`
 - `location IS NOT NULL` and matches `%, %` pattern
 - `is_verified = true`


### PR DESCRIPTION
## What changed

Updates `src/technical/backend.md` to document recent backend improvements.

### API Endpoints
- Split flat table into grouped sections (Auth, Profile, Events, Admin, Other)
- Added avatar/cover image endpoints and paginated list endpoints
- Added `GET /profile/map`

### New sections

**Pagination** — response shape, query params, cursor encoding (base64 JSON), slim schema table

**Map Endpoint** — how `split_part()` + cities JOIN resolves lat/lng in one query, filters applied, indexes used

**Email Templates** — Jinja2 template list with variables, design decisions (table layout, inline CSS, MSO conditionals, responsive), SMTP config table with App Password note

**Project structure** — added `app/templates/email/`