### PR TITLE
Add documentation-themed SVG favicon

### DIFF
--- a/src/.vitepress/config.ts
+++ b/src/.vitepress/config.ts
@@ -7,6 +7,8 @@ export default withMermaid(
     description: "Technical and project documentation for the IU Alumni platform",
     base: "/docs/",
 
+    head: [["link", { rel: "icon", href: "/docs/favicon.svg", type: "image/svg+xml" }]],
+
     themeConfig: {
       logo: "/logo.svg",
       siteTitle: "IU Alumni Docs",

--- a/src/public/favicon.svg
+++ b/src/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <!-- Book cover -->
+  <rect x="8" y="6" width="40" height="52" rx="4" ry="4" fill="#3b82f6"/>
+  <!-- Book spine -->
+  <rect x="8" y="6" width="8" height="52" rx="2" ry="2" fill="#1d4ed8"/>
+  <!-- Page lines -->
+  <line x1="22" y1="20" x2="42" y2="20" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="22" y1="28" x2="42" y2="28" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="22" y1="36" x2="42" y2="36" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="22" y1="44" x2="34" y2="44" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds a favicon to the VitePress docs site deployed on GitHub Pages.

### Changes
- **`src/public/favicon.svg`** — A blue book icon (SVG) representing documentation
- **`src/.vitepress/config.ts`** — Registers the favicon via the `head` config option

The favicon will appear in browser tabs when visiting the deployed docs at `/docs/`.