### PR TITLE
Add mentor meetings notes

### DIFF
--- a/src/.vitepress/config.ts
+++ b/src/.vitepress/config.ts
@@ -143,6 +143,27 @@ export default withMermaid(
                 { text: "Team Meeting", link: "/sprints/sprint-12/team-meeting" },
               ],
             },
+            {
+              text: "Sprint 13",
+              collapsed: true,
+              items: [
+                { text: "Mentor Meeting", link: "/sprints/sprint-13/mentor-meeting" },
+              ],
+            },
+            {
+              text: "Sprint 14",
+              collapsed: true,
+              items: [
+                { text: "Mentor Meeting", link: "/sprints/sprint-14/mentor-meeting" },
+              ],
+            },
+            {
+              text: "Sprint 15",
+              collapsed: true,
+              items: [
+                { text: "Mentor Meeting", link: "/sprints/sprint-15/mentor-meeting" },
+              ],
+            },
           ],
         },
         {

--- a/src/sprints/sprint-13/mentor-meeting.md
+++ b/src/sprints/sprint-13/mentor-meeting.md
@@ -1,0 +1,37 @@
+# Mentor Meeting Summary
+
+- Date: June 12th, 2026
+
+## Kick-off
+
+* Discussed our plans for the new semester and the intended workflow for upcoming sprints.
+* Reviewed how we plan to organize development and track progress throughout the semester.
+
+## Mentor Feedback
+
+### Team Workflow
+
+* We were encouraged to maintain a consistent sprint-based workflow with regular planning and progress tracking.
+* The importance of keeping the project board up to date and ensuring task visibility was reinforced.
+
+### Extra Work Process
+
+* We were advised to establish a clear process for handling work completed outside of planned sprint tasks.
+* Any additional work should be documented and tracked to maintain transparency and ensure all contributions are visible.
+
+### Meeting Structure
+
+* Future mentor meetings will continue on a regular schedule.
+* Meetings should focus on project progress, process improvements, and any blockers encountered during the sprint.
+
+### Project Presentations
+
+* The presentation format for this semester was explained.
+* Presentations will include both in-person and online team members.
+* We should ensure responsibilities are distributed clearly and prepare the presentation so that all team members can participate effectively regardless of location.
+
+## Action Items
+
+* Define a process for documenting and tracking extra work completed outside the sprint plan.
+* Continue following a structured sprint workflow with regular planning and status updates.
+* Prepare for the updated presentation format, including coordination with remote team members.

--- a/src/sprints/sprint-13/mentor-meeting.md
+++ b/src/sprints/sprint-13/mentor-meeting.md
@@ -4,34 +4,34 @@
 
 ## Kick-off
 
-* Discussed our plans for the new semester and the intended workflow for upcoming sprints.
-* Reviewed how we plan to organize development and track progress throughout the semester.
+- Discussed our plans for the new semester and the intended workflow for upcoming sprints.
+- Reviewed how we plan to organize development and track progress throughout the semester.
 
 ## Mentor Feedback
 
 ### Team Workflow
 
-* We were encouraged to maintain a consistent sprint-based workflow with regular planning and progress tracking.
-* The importance of keeping the project board up to date and ensuring task visibility was reinforced.
+- We were encouraged to maintain a consistent sprint-based workflow with regular planning and progress tracking.
+- The importance of keeping the project board up to date and ensuring task visibility was reinforced.
 
 ### Extra Work Process
 
-* We were advised to establish a clear process for handling work completed outside of planned sprint tasks.
-* Any additional work should be documented and tracked to maintain transparency and ensure all contributions are visible.
+- We were advised to establish a clear process for handling work completed outside of planned sprint tasks.
+- Any additional work should be documented and tracked to maintain transparency and ensure all contributions are visible.
 
 ### Meeting Structure
 
-* Future mentor meetings will continue on a regular schedule.
-* Meetings should focus on project progress, process improvements, and any blockers encountered during the sprint.
+- Future mentor meetings will continue on a regular schedule.
+- Meetings should focus on project progress, process improvements, and any blockers encountered during the sprint.
 
 ### Project Presentations
 
-* The presentation format for this semester was explained.
-* Presentations will include both in-person and online team members.
-* We should ensure responsibilities are distributed clearly and prepare the presentation so that all team members can participate effectively regardless of location.
+- The presentation format for this semester was explained.
+- Presentations will include both in-person and online team members.
+- We should ensure responsibilities are distributed clearly and prepare the presentation so that all team members can participate effectively regardless of location.
 
 ## Action Items
 
-* Define a process for documenting and tracking extra work completed outside the sprint plan.
-* Continue following a structured sprint workflow with regular planning and status updates.
-* Prepare for the updated presentation format, including coordination with remote team members.
+- Define a process for documenting and tracking extra work completed outside the sprint plan.
+- Continue following a structured sprint workflow with regular planning and status updates.
+- Prepare for the updated presentation format, including coordination with remote team members.

--- a/src/sprints/sprint-14/mentor-meeting.md
+++ b/src/sprints/sprint-14/mentor-meeting.md
@@ -1,0 +1,63 @@
+# Sprint 13 - Mentor meeting
+
+- Date: June 17th, 2026
+
+## Progress Updates
+
+* Completed and received approval for the badge system designs:
+
+  * Badge achievement pop-up.
+  * Badges overview and progress page.
+* Drafted the initial backend and frontend tasks required for the badge feature.
+* Started implementing the frontend badge redesign.
+* Sprint 14 development is now in progress.
+
+## Sprint Planning
+
+* The scheduled sprint planning meeting could not be held due to timetable conflicts.
+* Development was started asynchronously based on previously agreed responsibilities.
+* The mentor emphasized that sprint planning should be completed **before** the sprint begins, with a clearly defined scope and assigned tasks.
+
+## Mentor Feedback
+
+### Improve Sprint Planning
+
+* Hold a short planning meeting before each sprint (Saturday or Sunday).
+* Define the full sprint scope before implementation begins.
+* Estimate effort and assign all tasks during planning.
+* Sprint commitments should be agreed upon collectively rather than relying solely on individual responsibility.
+
+### Break Down Large Tasks
+
+* Large tasks should be decomposed into smaller subtasks.
+* Smaller tasks:
+
+  * Improve transparency.
+  * Make progress easier to track.
+  * Are easier to schedule and complete.
+
+### Improve Team Coordination
+
+* We should ensure everyone knows:
+
+  * Their assigned tasks.
+  * The expected effort for the sprint.
+  * The work being carried out by the rest of the team.
+* The sprint backlog should be finalized before development starts instead of adding tasks throughout the sprint whenever possible.
+
+### Status Updates
+
+* Status updates should be viewed as progress updates rather than formal reports.
+* They should:
+
+  * Keep everyone informed of ongoing work.
+  * Demonstrate progress toward shared sprint goals.
+  * Encourage accountability and collaboration across the team.
+
+## Agreed Process Improvements
+
+* Hold a weekly sprint planning meeting before each sprint.
+* Finalize and estimate all sprint tasks before implementation begins.
+* Break large tasks into smaller, manageable units.
+* Improve commitment to the agreed sprint scope.
+* Use status updates to monitor overall team progress rather than focusing only on individual contributions.

--- a/src/sprints/sprint-14/mentor-meeting.md
+++ b/src/sprints/sprint-14/mentor-meeting.md
@@ -4,60 +4,60 @@
 
 ## Progress Updates
 
-* Completed and received approval for the badge system designs:
+- Completed and received approval for the badge system designs:
 
-  * Badge achievement pop-up.
-  * Badges overview and progress page.
-* Drafted the initial backend and frontend tasks required for the badge feature.
-* Started implementing the frontend badge redesign.
-* Sprint 14 development is now in progress.
+  - Badge achievement pop-up.
+  - Badges overview and progress page.
+- Drafted the initial backend and frontend tasks required for the badge feature.
+- Started implementing the frontend badge redesign.
+- Sprint 14 development is now in progress.
 
 ## Sprint Planning
 
-* The scheduled sprint planning meeting could not be held due to timetable conflicts.
-* Development was started asynchronously based on previously agreed responsibilities.
-* The mentor emphasized that sprint planning should be completed **before** the sprint begins, with a clearly defined scope and assigned tasks.
+- The scheduled sprint planning meeting could not be held due to timetable conflicts.
+- Development was started asynchronously based on previously agreed responsibilities.
+- The mentor emphasized that sprint planning should be completed **before** the sprint begins, with a clearly defined scope and assigned tasks.
 
 ## Mentor Feedback
 
 ### Improve Sprint Planning
 
-* Hold a short planning meeting before each sprint (Saturday or Sunday).
-* Define the full sprint scope before implementation begins.
-* Estimate effort and assign all tasks during planning.
-* Sprint commitments should be agreed upon collectively rather than relying solely on individual responsibility.
+- Hold a short planning meeting before each sprint (Saturday or Sunday).
+- Define the full sprint scope before implementation begins.
+- Estimate effort and assign all tasks during planning.
+- Sprint commitments should be agreed upon collectively rather than relying solely on individual responsibility.
 
 ### Break Down Large Tasks
 
-* Large tasks should be decomposed into smaller subtasks.
-* Smaller tasks:
+- Large tasks should be decomposed into smaller subtasks.
+- Smaller tasks:
 
-  * Improve transparency.
-  * Make progress easier to track.
-  * Are easier to schedule and complete.
+  - Improve transparency.
+  - Make progress easier to track.
+  - Are easier to schedule and complete.
 
 ### Improve Team Coordination
 
-* We should ensure everyone knows:
+- We should ensure everyone knows:
 
-  * Their assigned tasks.
-  * The expected effort for the sprint.
-  * The work being carried out by the rest of the team.
-* The sprint backlog should be finalized before development starts instead of adding tasks throughout the sprint whenever possible.
+  - Their assigned tasks.
+  - The expected effort for the sprint.
+  - The work being carried out by the rest of the team.
+- The sprint backlog should be finalized before development starts instead of adding tasks throughout the sprint whenever possible.
 
 ### Status Updates
 
-* Status updates should be viewed as progress updates rather than formal reports.
-* They should:
+- Status updates should be viewed as progress updates rather than formal reports.
+- They should:
 
-  * Keep everyone informed of ongoing work.
-  * Demonstrate progress toward shared sprint goals.
-  * Encourage accountability and collaboration across the team.
+  - Keep everyone informed of ongoing work.
+  - Demonstrate progress toward shared sprint goals.
+  - Encourage accountability and collaboration across the team.
 
 ## Agreed Process Improvements
 
-* Hold a weekly sprint planning meeting before each sprint.
-* Finalize and estimate all sprint tasks before implementation begins.
-* Break large tasks into smaller, manageable units.
-* Improve commitment to the agreed sprint scope.
-* Use status updates to monitor overall team progress rather than focusing only on individual contributions.
+- Hold a weekly sprint planning meeting before each sprint.
+- Finalize and estimate all sprint tasks before implementation begins.
+- Break large tasks into smaller, manageable units.
+- Improve commitment to the agreed sprint scope.
+- Use status updates to monitor overall team progress rather than focusing only on individual contributions.

--- a/src/sprints/sprint-15/mentor-meeting.md
+++ b/src/sprints/sprint-15/mentor-meeting.md
@@ -1,0 +1,62 @@
+# Sprint 14 - Mentor Meeting
+
+- Date: June 22th, 2026
+
+## Key Discussion Points
+
+### Sprint Completion Definition
+
+* We discussed how to define when a sprint is actually “done.”
+* Currently, tasks are considered complete once reviewed, even if not merged.
+* Mentor highlighted that review alone is not sufficient, since tasks may still require rework.
+
+### Work in Review
+
+* A significant portion of estimated work is still in review state.
+* This creates uncertainty when closing Sprint 14 and planning Sprint 15.
+* Work in review should still be treated as active workload.
+
+### Sprint Planning and Carryover
+
+* Starting a new sprint while previous tasks are unresolved affects estimation accuracy.
+* Unfinished review work may impact capacity in the next sprint.
+
+## Mentor Feedback
+
+### Definition of Done
+
+* A task should only be considered complete when:
+  * It is reviewed
+  * Required fixes are applied
+  * It is merged
+* “In review” should not be treated as “done” for sprint closure.
+
+### Closing Sprints Properly
+
+* We should fully close the previous sprint before starting the next one.
+* Unmerged tasks should not remain open across sprint boundaries when planning.
+
+### Include Review Work in Planning
+
+* Code review is part of sprint workload and should be explicitly estimated.
+* Reviewer capacity must be considered alongside development effort.
+
+### Improve Sprint Flow
+
+* Avoid concentrating reviews at the end of the sprint.
+* Instead, we should distribute review activity throughout the sprint to reduce bottlenecks and context switching.
+
+### Better Estimation and Buffering
+
+* Sprint planning should include buffer for:
+  * Review time
+  * Potential rework after feedback
+* This improves predictability and reduces overcommitment.
+
+## Agreed Adjustments
+
+* Treat “in review” tasks as incomplete until merged.
+* Close Sprint 14 only after all review and merging is finished.
+* Include review capacity explicitly in Sprint planning.
+* Spread review work more evenly across the sprint.
+* Account for review and rework cycles in sprint estimation.

--- a/src/sprints/sprint-15/mentor-meeting.md
+++ b/src/sprints/sprint-15/mentor-meeting.md
@@ -6,57 +6,57 @@
 
 ### Sprint Completion Definition
 
-* We discussed how to define when a sprint is actually “done.”
-* Currently, tasks are considered complete once reviewed, even if not merged.
-* Mentor highlighted that review alone is not sufficient, since tasks may still require rework.
+- We discussed how to define when a sprint is actually “done.”
+- Currently, tasks are considered complete once reviewed, even if not merged.
+- Mentor highlighted that review alone is not sufficient, since tasks may still require rework.
 
 ### Work in Review
 
-* A significant portion of estimated work is still in review state.
-* This creates uncertainty when closing Sprint 14 and planning Sprint 15.
-* Work in review should still be treated as active workload.
+- A significant portion of estimated work is still in review state.
+- This creates uncertainty when closing Sprint 14 and planning Sprint 15.
+- Work in review should still be treated as active workload.
 
 ### Sprint Planning and Carryover
 
-* Starting a new sprint while previous tasks are unresolved affects estimation accuracy.
-* Unfinished review work may impact capacity in the next sprint.
+- Starting a new sprint while previous tasks are unresolved affects estimation accuracy.
+- Unfinished review work may impact capacity in the next sprint.
 
 ## Mentor Feedback
 
 ### Definition of Done
 
-* A task should only be considered complete when:
-  * It is reviewed
-  * Required fixes are applied
-  * It is merged
-* “In review” should not be treated as “done” for sprint closure.
+- A task should only be considered complete when:
+  - It is reviewed
+  - Required fixes are applied
+  - It is merged
+- “In review” should not be treated as “done” for sprint closure.
 
 ### Closing Sprints Properly
 
-* We should fully close the previous sprint before starting the next one.
-* Unmerged tasks should not remain open across sprint boundaries when planning.
+- We should fully close the previous sprint before starting the next one.
+- Unmerged tasks should not remain open across sprint boundaries when planning.
 
 ### Include Review Work in Planning
 
-* Code review is part of sprint workload and should be explicitly estimated.
-* Reviewer capacity must be considered alongside development effort.
+- Code review is part of sprint workload and should be explicitly estimated.
+- Reviewer capacity must be considered alongside development effort.
 
 ### Improve Sprint Flow
 
-* Avoid concentrating reviews at the end of the sprint.
-* Instead, we should distribute review activity throughout the sprint to reduce bottlenecks and context switching.
+- Avoid concentrating reviews at the end of the sprint.
+- Instead, we should distribute review activity throughout the sprint to reduce bottlenecks and context switching.
 
 ### Better Estimation and Buffering
 
-* Sprint planning should include buffer for:
-  * Review time
-  * Potential rework after feedback
-* This improves predictability and reduces overcommitment.
+- Sprint planning should include buffer for:
+  - Review time
+  - Potential rework after feedback
+- This improves predictability and reduces overcommitment.
 
 ## Agreed Adjustments
 
-* Treat “in review” tasks as incomplete until merged.
-* Close Sprint 14 only after all review and merging is finished.
-* Include review capacity explicitly in Sprint planning.
-* Spread review work more evenly across the sprint.
-* Account for review and rework cycles in sprint estimation.
+- Treat “in review” tasks as incomplete until merged.
+- Close Sprint 14 only after all review and merging is finished.
+- Include review capacity explicitly in Sprint planning.
+- Spread review work more evenly across the sprint.
+- Account for review and rework cycles in sprint estimation.


### PR DESCRIPTION
Add and sync meetings (last 3 sprints) notes to the project docs.
- Organize meetings recordings
- Convert to transcripts
- Summarize into notes
- Add to vitepress