### PR TITLE
docs(sprint-13): team meeting — work assignments + testing checkpoints

### DIFF
--- a/src/.vitepress/config.ts
+++ b/src/.vitepress/config.ts
@@ -158,7 +158,9 @@ export default withMermaid(
               text: "Sprint 13",
               collapsed: true,
               items: [
+                { text: "Client Meeting", link: "/sprints/sprint-13/client-meeting" },
                 { text: "Mentor Meeting", link: "/sprints/sprint-13/mentor-meeting" },
+                { text: "Team Meeting", link: "/sprints/sprint-13/team-meeting" },
               ],
             },
             {

--- a/src/.vitepress/config.ts
+++ b/src/.vitepress/config.ts
@@ -151,6 +151,7 @@ export default withMermaid(
               text: "Sprint 12",
               collapsed: true,
               items: [
+                { text: "Client Meeting", link: "/sprints/sprint-12/client-meeting" },
                 { text: "Team Meeting", link: "/sprints/sprint-12/team-meeting" },
               ],
             },
@@ -158,7 +159,6 @@ export default withMermaid(
               text: "Sprint 13",
               collapsed: true,
               items: [
-                { text: "Client Meeting", link: "/sprints/sprint-13/client-meeting" },
                 { text: "Mentor Meeting", link: "/sprints/sprint-13/mentor-meeting" },
                 { text: "Team Meeting", link: "/sprints/sprint-13/team-meeting" },
               ],

--- a/src/project/team.md
+++ b/src/project/team.md
@@ -8,6 +8,10 @@
 - Ghadeer Akleh: Frontend Developer and Configuration Manager
 - Aleksandr Kovalev: Project Tester
 
+## Current sprint responsibilities
+
+Sprint-level work ownership lives alongside the sprint's notes. For the active sprint see [Sprint 13 — Team Meeting](../sprints/sprint-13/team-meeting.md), which breaks the prioritised scope down by owner and lists Alex's testing checkpoints.
+
 ## Team Calendar
 
 Our calendar tracks recurring meetings and members' week availability.

--- a/src/requirements/functional.md
+++ b/src/requirements/functional.md
@@ -8,7 +8,7 @@
 ## Event Management
 
 - [x] **FR5**: Fix and optimize event creation workflow with proper validation and error handling [issued](../sprints/sprint-2/client-meeting.md)
-- [ ] **FR6**: Send automatic notifications upon event creation to relevant users (e.g., followers, location-based notifications) [issued](../sprints/sprint-2/client-meeting.md), [reaffirmed](../sprints/sprint-13/client-meeting.md)
+- [ ] **FR6**: Send automatic notifications upon event creation to relevant users (e.g., followers, location-based notifications) [issued](../sprints/sprint-2/client-meeting.md), [reaffirmed](../sprints/sprint-12/client-meeting.md)
 
   **Definition of success**
 
@@ -35,7 +35,7 @@
 
 ## Social Features
 
-- [ ] **FR8**: Add follow request feature enabling users to send, accept, and reject connection requests [issued](../sprints/sprint-2/client-meeting.md), [refined](../sprints/sprint-13/client-meeting.md)
+- [ ] **FR8**: Add follow request feature enabling users to send, accept, and reject connection requests [issued](../sprints/sprint-2/client-meeting.md), [refined](../sprints/sprint-12/client-meeting.md)
 
   **Definition of success**
 
@@ -47,7 +47,7 @@
   - [ ] User can unfollow a person or a location at any time from their followers/following management screen.
   - [ ] Followers / Following counters appear on the profile (UI covered by [FR10](#user-profile)).
 
-- [ ] **FR9**: Implement notification system for follow activities (requests, accepts, new followers) [issued](../sprints/sprint-2/client-meeting.md), [refined](../sprints/sprint-13/client-meeting.md)
+- [ ] **FR9**: Implement notification system for follow activities (requests, accepts, new followers) [issued](../sprints/sprint-2/client-meeting.md), [refined](../sprints/sprint-12/client-meeting.md)
 
   **Definition of success**
 
@@ -141,7 +141,7 @@
 
 - [x] **FR21**: Implement automated email notification system for key triggers including event registration confirmations, event reminders, and announcements
 
-- [ ] **FR26**: Notify joined participants when an event they have joined changes [issued](../sprints/sprint-13/client-meeting.md)
+- [ ] **FR26**: Notify joined participants when an event they have joined changes [issued](../sprints/sprint-12/client-meeting.md)
 
   **Definition of success**
 
@@ -159,7 +159,7 @@
   - [ ] Successive changes within ~5 min are bundled into a single message so a quick burst of edits doesn't spam attendees.
   - [ ] Cancellation is **always** delivered immediately, never batched.
 
-- [ ] **FR27**: Notify event creators when their event's participation changes [issued](../sprints/sprint-13/client-meeting.md)
+- [ ] **FR27**: Notify event creators when their event's participation changes [issued](../sprints/sprint-12/client-meeting.md)
 
   **Definition of success**
 
@@ -171,14 +171,14 @@
 
 ## User Roles & Permissions
 
-- [ ] **FR22**: Support distinct user roles with appropriate access levels including Admin users with full management capabilities for alumni data and events, and Alumni users with limited access focused on event registration only [issued](../sprints/sprint-1/client-meeting.md), [expanded](../sprints/sprint-13/client-meeting.md)
+- [ ] **FR22**: Support distinct user roles with appropriate access levels including Admin users with full management capabilities for alumni data and events, and Alumni users with limited access focused on event registration only [issued](../sprints/sprint-1/client-meeting.md), [expanded](../sprints/sprint-12/client-meeting.md)
 
   **Definition of success**
 
   Roles supported
   - [x] **Admin** — full management of alumni records, events, badges, projects.
   - [x] **Alumni** — graduates. Required to provide a graduation year. Default role after manual approval.
-  - [ ] **Alumni Friend** *(new — per [sprint-13 client meeting](../sprints/sprint-13/client-meeting.md))* — university staff, drop-outs who stayed in the community, and other non-graduate community members. Verified manually. **No graduation year**; their profile shows the "Alumni Friend" label instead, plus a free-text bio describing their relationship to the community.
+  - [ ] **Alumni Friend** *(new — per [sprint-12 client meeting](../sprints/sprint-12/client-meeting.md))* — university staff, drop-outs who stayed in the community, and other non-graduate community members. Verified manually. **No graduation year**; their profile shows the "Alumni Friend" label instead, plus a free-text bio describing their relationship to the community.
 
   Distinctions in the UI
   - [ ] Alumni Friends are visibly distinct on profile cards and lists (label or chip in lieu of the graduation-year tag).
@@ -190,11 +190,11 @@
 
 ## Payment & Donations
 
-- [ ] **FR24**: Implement a field for donations or payment of event fees with link-based payment processing (e.g., Tinkoff) without requiring a legal entity for handling funds [issued](../sprints/sprint-6/client-meeting.md), [scoped](../sprints/sprint-13/client-meeting.md)
+- [ ] **FR24**: Implement a field for donations or payment of event fees with link-based payment processing (e.g., Tinkoff) without requiring a legal entity for handling funds [issued](../sprints/sprint-6/client-meeting.md), [scoped](../sprints/sprint-12/client-meeting.md)
 
   **Definition of success**
 
-  Per the sprint-13 client meeting, "Projects" are a **separate entity from events** — a cause alumni create that others contribute money to (examples: Alumni Lounge Zone, scholarships, planting trees).
+  Per the sprint-12 client meeting, "Projects" are a **separate entity from events** — a cause alumni create that others contribute money to (examples: Alumni Lounge Zone, scholarships, planting trees).
 
   Project entity fields
   - [ ] Banner / cover image
@@ -209,7 +209,7 @@
   - [ ] Admin can close / archive a project.
   - [ ] Each contribution is logged against the project (handled by FR25).
 
-- [ ] **FR25**: Allow admins to track donators and payments associated with events for reporting purposes (maybe with a form) [issued](../sprints/sprint-11/client-meeting.md), [scoped](../sprints/sprint-13/client-meeting.md)
+- [ ] **FR25**: Allow admins to track donators and payments associated with events for reporting purposes (maybe with a form) [issued](../sprints/sprint-11/client-meeting.md), [scoped](../sprints/sprint-12/client-meeting.md)
 
   **Definition of success**
 

--- a/src/requirements/quality-attributes.md
+++ b/src/requirements/quality-attributes.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 - [Priority Matrix](#priority-matrix)
+- [Portability](#portability)
 - [Usability](#usability)
 - [Performance](#performance)
 - [Reliability](#reliability)
@@ -133,7 +134,13 @@ The prioritization follows a risk-adjusted value approach:
 This approach ensures we deliver a reliable, functional platform first,
 then enhance features based on user feedback.
 
-## Usability
+## Portability
+
+Migrating the platform from external infrastructure to university-owned
+servers is the dominant portability scenario for the project. It cuts
+across availability, data preservation, and operational handover — but
+the *attribute under test* is the system's ability to be relocated to a
+new environment without breaking.
 
 ### QAS101
 
@@ -156,6 +163,8 @@ event management, social features).
 
 Success: Total cumulative downtime ≤ 1 hour, with no user-visible
 errors during migration.
+
+## Usability
 
 ### QAS102
 

--- a/src/sprints/sprint-12/client-meeting.md
+++ b/src/sprints/sprint-12/client-meeting.md
@@ -1,4 +1,4 @@
-# Sprint 13 - Client meeting summary
+# Sprint 12 - Client meeting summary
 
 - Date: June 5th, 2026
 - First client meeting of the new semester; agenda is a follow-up on items
@@ -124,7 +124,7 @@
   - Allowed to add a free-text bio explaining how they relate to the
     community.
 
-## Prioritization of features
+## Prioritization for the sprint
 
 In this order:
 

--- a/src/sprints/sprint-13/client-meeting.md
+++ b/src/sprints/sprint-13/client-meeting.md
@@ -124,7 +124,7 @@
   - Allowed to add a free-text bio explaining how they relate to the
     community.
 
-## Prioritization for the sprint
+## Prioritization of features
 
 In this order:
 

--- a/src/sprints/sprint-13/team-meeting.md
+++ b/src/sprints/sprint-13/team-meeting.md
@@ -1,0 +1,40 @@
+# Sprint 13 - Team Meeting
+
+- Date: Following the [June 5th client meeting](./client-meeting.md).
+- Purpose: divide the prioritised scope from the client meeting between team members and lock in testing checkpoints.
+
+## Work assignments
+
+The team agreed on the following ownership for the deliverables that came out of the client meeting:
+
+| Track | Owner | Notes |
+| --- | --- | --- |
+| Migration · verification | Ahmad Helaly | Single owner so the rest of the team can work in parallel. |
+| University mail · password recovery | Ahmad Helaly | Follow-up on the SSO / breach discussion from the client meeting. |
+| Backend — User Profile | Ahmad Helaly | Schema and endpoint changes that the redesigned profile needs. |
+| Profile redesign · badges | Roukaya Mohammed | Covers [FR10](../../requirements/functional#user-profile) end-to-end (mockups, mobile UI, badge popup). |
+| Notifications | Roukaya Mohammed | New event · followed-user · event-changed · creator-on-join ([FR6](../../requirements/functional#event-management), [FR26 / FR27](../../requirements/functional#notifications)). |
+| Follow feature — frontend | Ghadeer Akleh | Mobile UI for follow flow, follower / following list, follow-location. |
+| Follow feature — backend | Majed Naser | API for mutual follow, follow-location, activity feed. |
+| Bugs — frontend | Ghadeer Akleh | Standing bucket for any UI defects surfaced this sprint. |
+| Bugs — backend | Majed Naser | Standing bucket for backend defects. |
+| Testing | Aleksandr Kovalev | Sprint-13 test pass; checkpoints below. |
+| Project management | All | Shared facilitation, board hygiene, ceremonies. |
+| Reporting | All | Each owner writes the report section for their track. |
+
+## Testing checkpoints
+
+Alex runs the test pass against the merged work and delivers a written report at each checkpoint so blockers surface early instead of at end-of-sprint:
+
+| Day | Deliverable |
+| --- | --- |
+| Tuesday | First test report (covers merged work to date). |
+| Thursday | Second test report. |
+| Sunday | Third test report. |
+| Monday | Sprint test summary — feeds into the team retrospective. |
+
+## Notes
+
+- The follow feature is owned end-to-end (FE + BE) so the contract between Ghadeer and Majed stays tight; both sync on the API shape before Ghadeer starts wiring it up.
+- The bug buckets are intentionally separate from the feature tracks so a hot-fix doesn't block someone else's planned work.
+- Profile redesign and notifications are scoped together under Roukaya since the celebratory popup and the notification copy share UI primitives.

--- a/src/sprints/sprint-13/team-meeting.md
+++ b/src/sprints/sprint-13/team-meeting.md
@@ -1,6 +1,6 @@
 # Sprint 13 - Team Meeting
 
-- Date: Following the [June 5th client meeting](./client-meeting.md).
+- Date: Following the [June 5th client meeting](../sprint-12/client-meeting.md).
 - Purpose: divide the prioritised scope from the client meeting between team members and lock in testing checkpoints.
 
 ## Work assignments


### PR DESCRIPTION
Captures the whiteboard from the team planning meeting that followed the [sprint-13 client meeting](https://github.com/iu-alumni/docs/blob/main/src/sprints/sprint-13/client-meeting.md).

### Adds

- **`src/sprints/sprint-13/team-meeting.md`** — work-assignments table (one row per track, one owner each), testing-checkpoint table, and rationale notes.
- **`src/project/team.md`** — short pointer under Roles directing readers to the active sprint's ownership breakdown. Permanent roles stay where they are; sprint-level work lives with the sprint.
- **`src/.vitepress/config.ts`** — sidebar entry for sprint-13 now lists Client / Mentor / Team meetings (was Mentor only).

### Assignments

| Track | Owner |
|---|---|
| Migration / Uni mail / Backend user profile | Ahmad Helaly |
| Profile redesign / badges / Notifications | Roukaya Mohammed |
| Follow feature — frontend / Bugs frontend | Ghadeer Akleh |
| Follow feature — backend / Bugs backend | Majed Naser |
| Testing (with Tue / Thu / Sun checkpoint reports + Mon summary) | Aleksandr Kovalev |
| Project management / Reporting | All |

The follow feature is split FE/BE so the API contract gets agreed up front. Bug buckets are deliberately separate from feature tracks so hot-fixes don't block planned work.