### PR TITLE
docs(functional): reflect Projects v1 as shipped

### DIFF
--- a/src/requirements/functional.md
+++ b/src/requirements/functional.md
@@ -108,7 +108,7 @@
   - [x] **Badges** — horizontal scroll, earned tiles with tiered gold/silver/bronze rings, locked tiles with dashed gray ring, lock chip, mini progress bar, and tap-for-info icon. Full catalog, criteria, and per-badge implementation status live in [Badges Catalog & Status](./badges.md). *(Covered by [`backend#98`](https://github.com/iu-alumni/iu-alumni-backend/pull/98) and [`mobile#125`](https://github.com/iu-alumni/iu-alumni-mobile/pull/125).)*
   - [x] **Participated events** — horizontal scroll of event cards.
   - [x] **Created events** — same pattern, only shown on own profile.
-  - [ ] **Projects** (donations / scholarships / lounge) — designed in mockups, not yet implemented.
+  - [x] **Projects** — "Created projects" (all statuses) and "Contributed projects" (approved-only, hidden on another user's profile when the list is empty) sections on the profile. Backend contract in [`backend#132`](https://github.com/iu-alumni/iu-alumni-backend/pull/132); mobile UI in [`mobile#148`](https://github.com/iu-alumni/iu-alumni-mobile/pull/148). Full spec under [FR24](#payment--donations).
   - [ ] **Followers / Following counters** — rendered under the identity row; gated on [FR8](#social-features).
 
   Interactions
@@ -190,31 +190,57 @@
 
 ## Payment & Donations
 
-- [ ] **FR24**: Implement a field for donations or payment of event fees with link-based payment processing (e.g., Tinkoff) without requiring a legal entity for handling funds [issued](../sprints/sprint-6/client-meeting.md), [scoped](../sprints/sprint-12/client-meeting.md)
+- [x] **FR24**: Alumni-created **Projects** with admin approval, a link-based donate action, and a self-reported raised-total that drives a public progress bar. Verified payment integration is deferred to FR24-b. [issued](../sprints/sprint-6/client-meeting.md), [scoped](../sprints/sprint-12/client-meeting.md)
 
-  **Definition of success**
+  Per the sprint-12 client meeting, "Projects" are a **separate entity from events** — a cause alumni create that others rally around (examples: Alumni Lounge Zone, scholarships, planting trees). v1 ships the full lifecycle end-to-end: create → admin approve → contributors open the donation link → self-report the amount → the project's raised total and progress bar update. Real payment verification is a follow-up (see FR24-b).
 
-  Per the sprint-12 client meeting, "Projects" are a **separate entity from events** — a cause alumni create that others contribute money to (examples: Alumni Lounge Zone, scholarships, planting trees).
+  **v1 invariant** — `donation_link` and `goal_amount` are both **required** and non-zero on every project. There is no support-only variant in v1; every project is a fundraiser. Editing either field on an approved project resets it to pending review.
 
   Project entity fields
-  - [ ] Banner / cover image
-  - [ ] Title
-  - [ ] Free-text description ("what / why")
-  - [ ] "Contribute" / "Donate" button → link-based payment (Tinkoff or equivalent)
-  - [ ] Owner contact field so contributors can reach out with questions
-  - [ ] *Anna to confirm the exact field list — placeholder above based on the meeting.*
+  - [x] Cover image (base64, optional — same convention as events)
+  - [x] Title (required)
+  - [x] Free-text description (required)
+  - [x] Donation link (required, http/https) — external URL (Tinkoff, etc.) opened when contributors tap Donate
+  - [x] Goal amount (required, positive integer, ₽)
+  - [x] Raised amount (₽, sums self-reported donations from `POST /projects/{id}/donations`)
+  - [x] Contributors (`contributors_ids[]`) and owner (implicit — the creator; contactable via their profile / Telegram)
+  - [ ] Explicit owner-contact field beyond the profile link — *deferred; owner profile currently satisfies the "how do I reach them" need.*
 
   Lifecycle
-  - [ ] Project owner can edit project details while the project is open.
-  - [ ] Admin can close / archive a project.
-  - [ ] Each contribution is logged against the project (handled by FR25).
+  - [x] Any authenticated alumnus can create a project. It starts as **pending** (`approved = null`) and is invisible to non-owners.
+  - [x] **Admin approval** is required before the project appears in the public list. Admin can approve, decline, or send back to pending (`POST /admin/projects/{approve,decline,unapprove}/{id}`).
+  - [x] Project owner can edit details. Editing the title, description, cover, donation link, or goal amount of an approved project resets it to pending so the change goes through review again.
+  - [x] Owner or admin can delete a project.
 
-- [ ] **FR25**: Allow admins to track donators and payments associated with events for reporting purposes (maybe with a form) [issued](../sprints/sprint-11/client-meeting.md), [scoped](../sprints/sprint-12/client-meeting.md)
+  Contribute / retract (v1 = click-based, no money involved)
+  - [x] Any authenticated alumnus can mark themselves as a contributor to an **approved** project (`POST /projects/{id}/contributors`). Idempotent — duplicate call → 400. Admins cannot contribute.
+  - [x] Any contributor can retract (`POST /projects/{id}/contributors/remove`).
+  - [x] Contributor count is derived from `contributors_ids` — no separate contributions table in v1.
 
-  **Definition of success**
+  Donate flow (v1 = self-reported)
+  - [x] Contributor taps **Donate** → the external donation link opens in the system browser.
+  - [x] On return, the mobile app prompts "How much did you donate?" and posts to `POST /projects/{id}/donations {amount}`.
+  - [x] Backend increments the project's `raised_amount`; UI refreshes the progress bar and the "₽X raised of ₽Y · N contributors" line.
+  - [ ] The reported amount is currently **unverified** — a user could enter any number. Real verification lands with FR24-b.
 
-  - [ ] Each contribution is logged with: contributor user id, project id, amount (when available), and timestamp.
-  - [ ] Admin can view the contributor list and totals per project.
+  Surface coverage
+  - [x] **Mobile** — Projects tab (Variant-B card: cover + title + description on top; progress bar + "₽X raised of ₽Y · N contributors"; contributor avatar stack + green Donate CTA), details screen, create/edit form (title, description, cover, donation link, goal), donate + contribute/retract flows, and the profile sections above. Real contributor avatars fetched in batch via `getUsersByIds`. [`mobile#148`](https://github.com/iu-alumni/iu-alumni-mobile/pull/148).
+  - [x] **Admin portal** — `/projects` page with status filter (pending / approved / declined / all); rows show title, owner, cover, status pill, contributor count, a `💳 Link` pill when a donation link exists, and an `N%` green pill when a goal is set; detail side-panel shows description, contributors, dates, a clickable donation link, and a fundraising block (progress bar + "₽X raised of ₽Y · N%"); approve / decline / reopen / send-back actions. [`frontend#77`](https://github.com/iu-alumni/iu-alumni-frontend/pull/77).
+  - [x] **Backend** — full CRUD, admin approve/decline/unapprove, contribute/retract, and `POST /projects/{id}/donations {amount}`. Schema in [`backend#132`](https://github.com/iu-alumni/iu-alumni-backend/pull/132); `donation_link` column in [`backend#140`](https://github.com/iu-alumni/iu-alumni-backend/pull/140); `goal_amount` + `raised_amount` + donate endpoint in [`backend#148`](https://github.com/iu-alumni/iu-alumni-backend/pull/148).
+
+- [ ] **FR24-b**: Verified payment integration on the Donate action (Tinkoff or equivalent) so raised totals reflect actual money rather than self-reported amounts. Deferred from FR24 v1 — v1 currently opens the donation link and then trusts the user's self-reported amount. Needs a separate `contributions` table with `contributor_id`, `project_id`, `amount`, `currency`, `paid_at`, `payment_ref`, plus provider webhooks. Provider choice + legal review (no legal entity) tracked separately.
+
+- [ ] **FR25**: Track per-donor amounts and expose an admin reporting view (top contributors, opt-out, contributor badge) for projects. [issued](../sprints/sprint-11/client-meeting.md), [scoped](../sprints/sprint-12/client-meeting.md)
+
+  **Definition of success** — the per-donor items are pre-conditioned on [FR24-b](#payment--donations) (verified payments). Until then, "contributions" are self-reported clicks and self-reported totals, so per-donor amounts and the reporting view are intentionally not built.
+
+  Still deferred
+  - [ ] Each contribution is logged with: contributor user id, project id, amount, timestamp — requires FR24-b.
   - [ ] Contributors can opt out of public listing for privacy.
   - [ ] A contributor optionally earns a **"Contributor"** badge (cross-reference to the [Badges Catalog](./badges.md)).
-  - [ ] Reporting view exposes total raised, contributor count, and (optionally) top contributors.
+  - [ ] Reporting view exposes per-donor amounts and top contributors.
+
+  What v1 already covers
+  - [x] Contributor list per project — derived from `contributors_ids`; exposed by [`backend#132`](https://github.com/iu-alumni/iu-alumni-backend/pull/132).
+  - [x] Contributor count per project — shown in the mobile card / details screen and in the admin table + side-panel ([`mobile#148`](https://github.com/iu-alumni/iu-alumni-mobile/pull/148), [`frontend#77`](https://github.com/iu-alumni/iu-alumni-frontend/pull/77)).
+  - [x] Raised total per project — "₽X raised of ₽Y" plus progress bar in mobile and admin surfaces; totals in the admin side-panel ([`backend#148`](https://github.com/iu-alumni/iu-alumni-backend/pull/148), [`mobile#148`](https://github.com/iu-alumni/iu-alumni-mobile/pull/148), [`frontend#77`](https://github.com/iu-alumni/iu-alumni-frontend/pull/77)).


### PR DESCRIPTION
## Summary

Update `src/requirements/functional.md` to document what actually shipped for Projects in v1 across backend, mobile, and the admin portal.

- **FR24** rewritten: the v1 shell is complete end-to-end (create -> admin approve -> contributors open donation link -> self-report amount -> raised total + progress bar). Every satisfied acceptance criterion is ticked. Added the new **v1 invariant** that `donation_link` and `goal_amount` are both required and non-zero, and that editing either on an approved project resets it to pending.
- **FR24-b** split out and kept deferred: verified payment integration (Tinkoff/etc.) so raised totals reflect real money instead of self-reported amounts.
- **FR10** Projects bullet flipped to shipped, pointing at the mobile PR.
- **FR25** partial: contributor list, contributor count, and raised total per project marked shipped; per-donor amounts, opt-out, contributor badge, and reporting view remain deferred pending FR24-b.

Cross-references: [`backend#132`](https://github.com/iu-alumni/iu-alumni-backend/pull/132), [`backend#140`](https://github.com/iu-alumni/iu-alumni-backend/pull/140), [`backend#148`](https://github.com/iu-alumni/iu-alumni-backend/pull/148), [`mobile#148`](https://github.com/iu-alumni/iu-alumni-mobile/pull/148), [`frontend#77`](https://github.com/iu-alumni/iu-alumni-frontend/pull/77).

## Test plan

- [x] `npx markdownlint src/requirements/functional.md` — clean (MD051 anchors verified against existing `#payment--donations` heading).
- [x] Reviewer to sanity-check that FR24 accurately mirrors what's in the referenced PRs.

---
Closes iu-alumni/docs#97
